### PR TITLE
Use relative imports in __init__.py

### DIFF
--- a/jsonform/__init__.py
+++ b/jsonform/__init__.py
@@ -3,4 +3,4 @@
 
 __version__ = '0.0.2'
 
-from jsonform import JsonForm
+from .jsonform import JsonForm


### PR DESCRIPTION
Otherwise this generate a cyclical import thanks to both the package and the file being called `jsonform`.